### PR TITLE
Remove `close front window`

### DIFF
--- a/Open-Browser-Windows.applescript
+++ b/Open-Browser-Windows.applescript
@@ -5,7 +5,6 @@ set socialURLList to {"https://facebook.com", "https://twitter.com"}
 -- Open URLs in googleURLList in new window
 tell application "Google Chrome"
 	activate
-	-- close front window
 	
 	-- Open Google Mail, Calendar
 	make new window


### PR DESCRIPTION
Removed `close front window` which fails with an error when Chrome is open with no open windows.

Fixes #2 